### PR TITLE
fix: dont include transactions with 0 ark amount

### DIFF
--- a/lib/utils/trueblockweight.js
+++ b/lib/utils/trueblockweight.js
@@ -587,7 +587,7 @@ class TrueBlockWeight {
 
         const payout = this.payouts.get(address).plus(this.feesPayouts.get(address))
         this.payouts.set(address, payout)
-        if (this.payouts.get(address).lt(this.minPayout)) {
+        if (this.payouts.get(address).lt(this.minPayout) || this.payouts.get(address).eg(0)) {
           logger.warn(`Payout to ${address} pending (min. value ${this.minPayout.div(ARKTOSHI).toNumber()}): ${this.payouts.get(address).div(ARKTOSHI).toFixed(8)}`)
           this.payouts.delete(address)
         } else {


### PR DESCRIPTION
I've noticed the second batch of requests done to `/transactions` endpoints failed due to one transaction which constantly had 0 amount in its transfer. This should prevent this. Note that my env variable for min payout is set to 0.