### PR TITLE
bump request timeout from 1000 to 5000ms

### DIFF
--- a/src/services/network.ts
+++ b/src/services/network.ts
@@ -107,7 +107,7 @@ export class Network {
                 const response = await axios.get(`${node}${endPoint}`, {
                     params,
                     headers: { "API-Version": 2 },
-                    timeout: 1000,
+                    timeout: 5000,
                 });
 
                 if (


### PR DESCRIPTION
I'm getting timeouts fairly frequently and I don't see a reason why not increase the timeout (5000ms is an arbitrary number here, that i think makes sense)

```
[2021-03-22 07:23:24.813 +0000] WARN  (Cryptology TBW): Error: timeout of 1000ms exceeded for URL: http://localhost:4003/api/delegates/deadlock/voters
[2021-03-22 07:23:24.813 +0000] ERROR (Cryptology TBW): Could not connect to any of the configured nodes.
```

I'm not running a potatoe server which is why I'm surprised I even keep hitting the timeout.