### PR TITLE
feat: subtract burned from total fees if column exists

### DIFF
--- a/src/utils/database-api.ts
+++ b/src/utils/database-api.ts
@@ -17,6 +17,7 @@ import {
 import { logger, Postgres } from "../services";
 import { Crypto } from "./crypto";
 import {
+    checkColumnExists,
     getCurrentVotersSince,
     getDelegateTransactions,
     getForgedBlocks,
@@ -46,13 +47,29 @@ export class DatabaseAPI {
         historyAmountBlocks: number
     ): Promise<ForgedBlock[]> {
         await this.psql.connect();
+
+        const checkColumnExistsQuery: string = checkColumnExists(
+            "blocks",
+            "burned_fee"
+        );
+
+        let result: Result = await this.psql.query(checkColumnExistsQuery);
+
+        let subtractBurnedFees = false;
+        if (result.rows.length === 1) {
+            subtractBurnedFees = true;
+        }
+
         const getForgedBlocksQuery: string = getForgedBlocks(
             delegatePublicKey,
             startBlockHeight,
             endBlockHeight,
-            historyAmountBlocks
+            historyAmountBlocks,
+            subtractBurnedFees
         );
-        const result: Result = await this.psql.query(getForgedBlocksQuery);
+
+        result = await this.psql.query(getForgedBlocksQuery);
+
         await this.psql.close();
 
         if (result.rows.length === 0) {

--- a/src/utils/database-api.ts
+++ b/src/utils/database-api.ts
@@ -55,10 +55,7 @@ export class DatabaseAPI {
 
         let result: Result = await this.psql.query(checkColumnExistsQuery);
 
-        let subtractBurnedFees = false;
-        if (result.rows.length === 1) {
-            subtractBurnedFees = true;
-        }
+        const subtractBurnedFees = result.rows.length === 1;
 
         const getForgedBlocksQuery: string = getForgedBlocks(
             delegatePublicKey,

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -1,5 +1,16 @@
 /**
  *
+ * @param tableName
+ * @param columnName
+ */
+export const checkColumnExists = (
+    tableName: string,
+    columnName: string
+): string =>
+    `SELECT 1 FROM information_schema.columns WHERE table_name = '${tableName}' and column_name = '${columnName}';`;
+
+/**
+ *
  * @param publicKey
  * @param startBlockHeight
  * @param endBlockHeight
@@ -9,10 +20,15 @@ export const getForgedBlocks = (
     publicKey: string,
     startBlockHeight: number,
     endBlockHeight: number,
-    limit: number
+    limit: number,
+    subtractBurnedFees: boolean
 ): string => {
     let query = `SELECT blocks.height, blocks.timestamp, blocks.reward, \
-                        blocks.total_fee AS "totalFee" \
+                        ${
+                            subtractBurnedFees
+                                ? "(blocks.total_fee - blocks.burned_fee)"
+                                : "blocks.total_fee"
+                        } AS "totalFee" \
           FROM public.blocks \
           WHERE blocks."generator_public_key" = '${publicKey}' \
           AND blocks.height >= ${startBlockHeight}`;


### PR DESCRIPTION
Adds support for the Solar network by checking if a `burned_fee` column is present in the `blocks` table before querying for the blocks data. If there is, the burned fee amount is subtracted from the total fee.