### PR TITLE
chore: remove solar specific code from V3.0 branch

### DIFF
--- a/src/utils/database-api.ts
+++ b/src/utils/database-api.ts
@@ -17,7 +17,6 @@ import {
 import { logger, Postgres } from "../services";
 import { Crypto } from "./crypto";
 import {
-    checkColumnExists,
     getCurrentVotersSince,
     getDelegateTransactions,
     getForgedBlocks,
@@ -48,24 +47,14 @@ export class DatabaseAPI {
     ): Promise<ForgedBlock[]> {
         await this.psql.connect();
 
-        const checkColumnExistsQuery: string = checkColumnExists(
-            "blocks",
-            "burned_fee"
-        );
-
-        let result: Result = await this.psql.query(checkColumnExistsQuery);
-
-        const subtractBurnedFees = result.rows.length === 1;
-
         const getForgedBlocksQuery: string = getForgedBlocks(
             delegatePublicKey,
             startBlockHeight,
             endBlockHeight,
-            historyAmountBlocks,
-            subtractBurnedFees
+            historyAmountBlocks
         );
 
-        result = await this.psql.query(getForgedBlocksQuery);
+        const result: Result = await this.psql.query(getForgedBlocksQuery);
 
         await this.psql.close();
 
@@ -144,13 +133,11 @@ export class DatabaseAPI {
 
     public async getCurrentVotersSince(
         delegatePublicKey: string,
-        delegateName: string,
         networkVersion: number,
         timestamp: BigNumber
     ): Promise<Map<string, BigNumber>> {
         const getCurrentVotersQuery: string = getCurrentVotersSince(
-            delegatePublicKey,
-            delegateName
+            delegatePublicKey
         );
 
         await this.psql.connect();
@@ -194,14 +181,12 @@ export class DatabaseAPI {
      */
     public async getVoterMutations(
         delegatePublicKey: string,
-        delegateName: string,
         startBlockHeight: number,
         networkVersion: number
     ): Promise<VoterMutation[]> {
         const getVoterSinceHeightQuery: string = getVoterSinceHeight(
             startBlockHeight,
-            delegatePublicKey,
-            delegateName
+            delegatePublicKey
         );
         await this.psql.connect();
         const result: Result = await this.psql.query(getVoterSinceHeightQuery);
@@ -222,8 +207,7 @@ export class DatabaseAPI {
 
                     const vote: string = DatabaseAPI.selectVote(
                         transaction.asset.votes,
-                        delegatePublicKey,
-                        delegateName
+                        delegatePublicKey
                     );
                     return {
                         height: new BigNumber(
@@ -264,17 +248,13 @@ export class DatabaseAPI {
 
     private static selectVote(
         votes: string[],
-        delegatePublicKey: string,
-        delegateName: string,
+        delegatePublicKey: string
     ): string {
         if (votes.length === 2) {
             if (votes[0].substr(1) === votes[1].substr(1)) {
                 return "";
             }
             if (votes[1].substr(1) === delegatePublicKey) {
-                return votes[1];
-            }
-            if (votes[1].substr(1) === delegateName) {
                 return votes[1];
             }
         }

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -1,16 +1,5 @@
 /**
  *
- * @param tableName
- * @param columnName
- */
-export const checkColumnExists = (
-    tableName: string,
-    columnName: string
-): string =>
-    `SELECT 1 FROM information_schema.columns WHERE table_name = '${tableName}' and column_name = '${columnName}';`;
-
-/**
- *
  * @param publicKey
  * @param startBlockHeight
  * @param endBlockHeight
@@ -20,15 +9,9 @@ export const getForgedBlocks = (
     publicKey: string,
     startBlockHeight: number,
     endBlockHeight: number,
-    limit: number,
-    subtractBurnedFees: boolean
+    limit: number
 ): string => {
-    let query = `SELECT blocks.height, blocks.timestamp, blocks.reward, \
-                        ${
-                            subtractBurnedFees
-                                ? "(blocks.total_fee - blocks.burned_fee)"
-                                : "blocks.total_fee"
-                        } AS "totalFee" \
+    let query = `SELECT blocks.height, blocks.timestamp, blocks.reward, blocks.total_fee AS "totalFee" \
           FROM public.blocks \
           WHERE blocks."generator_public_key" = '${publicKey}' \
           AND blocks.height >= ${startBlockHeight}`;
@@ -64,16 +47,13 @@ export const getVotingDelegates = (
     return query;
 };
 
-export const getCurrentVotersSince = (
-    delegatePublicKey: string,
-    delegateName: string
-): string => {
+export const getCurrentVotersSince = (delegatePublicKey: string): string => {
     return `SELECT * FROM ( \
     SELECT DISTINCT ON (transactions."sender_public_key") transactions."sender_public_key" AS "senderPublicKey", \
     transactions."asset", transactions."timestamp" \
     FROM transactions \
     WHERE transactions."type" = 3 AND transactions."type_group" = 1 \
-    AND (transactions."asset"->>'votes' LIKE '%+${delegatePublicKey}%' OR transactions."asset"->>'votes' LIKE '%+${delegateName}%') \
+    AND transactions."asset" @> '{"votes": ["+${delegatePublicKey}"]}' \
     ORDER BY transactions."sender_public_key", transactions."timestamp" DESC ) t \
     ORDER BY t."timestamp" DESC;`;
 };
@@ -85,14 +65,16 @@ export const getCurrentVotersSince = (
  */
 export const getVoterSinceHeight = (
     startBlockHeight: number,
-    delegatePublicKey: string,
-    delegateName: string
+    delegatePublicKey: string
 ): string => {
     return `SELECT transactions."asset", transactions."sender_public_key" AS "senderPublicKey", \ 
           blocks."height" \
           FROM transactions INNER JOIN blocks ON blocks."id" = transactions."block_id"  
           WHERE transactions."type" = 3 AND transactions."type_group" = 1 \
-          AND (transactions."asset"->>'votes' LIKE '%${delegatePublicKey}%' OR transactions."asset"->>'votes' LIKE '%${delegateName}%') \
+          AND ( \
+              transactions."asset" @> '{"votes": ["+${delegatePublicKey}"]}' \
+              OR transactions."asset" @> '{"votes": ["-${delegatePublicKey}"]}' \
+            ) \
           AND blocks.height >= ${startBlockHeight} ORDER BY blocks."height" ASC;`;
 };
 

--- a/src/utils/true-block-weight-engine.ts
+++ b/src/utils/true-block-weight-engine.ts
@@ -97,10 +97,7 @@ export class TrueBlockWeightEngine {
             const delegatePublicKey: string = Crypto.getPublicKeyFromSeed(
                 this.config.seed
             );
-            const delegateName = await this.network.getDelegateNameForSeed(
-                this.config.seed
-            );
-                
+
             logger.info("Retrieving blocks forged by delegate.");
             const forgedBlocks: ForgedBlock[] = await this.databaseAPI.getForgedBlocks(
                 delegatePublicKey,
@@ -130,7 +127,6 @@ export class TrueBlockWeightEngine {
             logger.info("Retrieving voters.");
             const voters: Voters = await this.getVoters(
                 delegatePublicKey,
-                delegateName,
                 forgedBlocks
             );
 
@@ -191,7 +187,6 @@ export class TrueBlockWeightEngine {
                 BigNumber
             > = await this.databaseAPI.getCurrentVotersSince(
                 delegatePublicKey,
-                delegateName,
                 this.networkVersion,
                 timestamp
             );
@@ -230,7 +225,6 @@ export class TrueBlockWeightEngine {
      */
     public async getVoters(
         delegatePublicKey: string,
-        delegateName: string,
         forgedBlocks: ForgedBlock[]
     ): Promise<Voters> {
         logger.info("Retrieving current voters from API.");
@@ -248,7 +242,6 @@ export class TrueBlockWeightEngine {
         logger.info("Retrieving voter mutations.");
         const voterMutations: VoterMutation[] = await this.databaseAPI.getVoterMutations(
             delegatePublicKey,
-            delegateName,
             this.startBlockHeight,
             this.networkVersion
         );


### PR DESCRIPTION
Reverts #112, #126 on the `V3.0` branch since those are specific to Solar only, and adjusts the SQL queries to check against an exact match.